### PR TITLE
Changing the hdf5 file create to work with multi-processing

### DIFF
--- a/wrapper-simulations-multipletimepoints.py
+++ b/wrapper-simulations-multipletimepoints.py
@@ -100,8 +100,6 @@ def run_sim(i, file_path, endgame_structure):
     with h5py.File(new_path, "w") as new_file:
         grp = new_file.create_group(f"draw_{str(i)}")
         endgame_sim.save(grp)
-        for name in grp:
-            print(name, type(grp[name]))
 
     return run_data
 


### PR DESCRIPTION
- The hdf5 files weren't being created because of a clash with multi-processing. HDF5 doesn't handle writing to the same file in parallel (see comment)[https://stackoverflow.com/questions/72217230/multiprocessing-writing-into-a-hdf5-file#comment127596960_72217230]. 
- As a workaround, we create a folder for each IU that contains a single hdf5 file for each run
- After an IU is finished running, it will combine these single files into 1 main file.

Currently it doesn't delete the temporary single run hdf5 files yet, but that should be added.